### PR TITLE
Filterbank utility command line version "0.20210206" checkpoint

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-This file is a version history of jl-blio amendments, beginning with 2021-01-15.  Entries appear in date descending order (newest first, oldest last).
+This file is a history of jl-blio amendments, beginning with 2021-01-06.  Entries appear in date descending order (newest first, oldest last).
 <br>
 <br>
 | Date | Contents |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,4 +10,5 @@ This file is a history of jl-blio amendments, beginning with 2021-01-06.  Entrie
 | | To do:
 | | * NIFS.
 | | * Support output in HDF5 format. |
+| | * Integrate with version ID from Project.toml |
 | 2021-02-06 | Began Filterbank utility version "0.20210206".

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,13 @@
+This file is a version history of jl-blio amendments, beginning with 2021-01-15.  Entries appear in date descending order (newest first, oldest last).
+<br>
+<br>
+| Date | Contents |
+| :--: | -- |
+| 2021-02-12 | Filterbank utility command line version "0.20210206" checkpoint. |
+| | 2 Functions:
+| | * Input Filterbank file information presentation, similar to blimpy.Waterfall(). |
+| | * Copy the input Filterbank file with filtering by elapsed time opy with in seconds from beginning and frequency in MHz. |
+| | To do:
+| | * NIFS.
+| | * Support output in HDF5 format. |
+| 2021-02-06 | Began Filterbank utility version "0.20210206".

--- a/src/Fb2FbCopy.jl
+++ b/src/Fb2FbCopy.jl
@@ -1,0 +1,138 @@
+import Base.Filesystem: filesize, isfile
+
+
+function eof_watch(io::IO, context::String)
+    flush(io)
+    println("eof_watch: $context, output file size = ", position(io))
+end
+
+
+function edited_size(num_size::Int64)::String
+    if num_size > 999999999
+        str = @sprintf("%.9f GB", Float64(num_size) / 1.0e9)
+    elseif num_size > 999999
+        str = @sprintf("%.6f MB", Float64(num_size) / 1.0e6)
+    elseif num_size > 999
+        str = @sprintf("%.3f KB", Float64(num_size) / 1.0e3)
+    else
+        str = @sprintf("%d bytes", num_size)
+    end
+    return str
+end
+
+
+function fb2fb_copy(header_in::Filterbank.Header, parms::PgmParameters)
+    t1 = time()
+    SEC_PER_DAY = 3600.0 * 24.0
+    println("fb2fb_copy: Input file path = ", parms.infile)
+    println("fb2fb_copy: Output file path = ", parms.outfile)
+    if parms.flag_debug
+        println("fb2fb_copy DEBUG: Input data size = ", edited_size(header_in.data_size))
+        @printf("fb2fb_copy DEBUG: Input data Shape = (%d, %d, %d)\n", 
+                header_in.nsamps, header_in.nifs, header_in.nchans)
+        @printf("fb2fb_copy DEBUG: Header size = %d bytes\n", header_in.header_size)
+        @printf("%s : %f\n", "Selected Start frequency (MHz)", parms.f_start)
+        @printf("%s : %f\n", "Selected Stop frequency (MHz)", parms.f_stop)
+    end
+    @printf("Selected Start time (in s, relative to 0) : %.3f\n", parms.t_start)
+    @printf("Selected Stop time (in s, relative to 0) : %.3f\n", parms.t_stop)
+   
+    # Initialize input and output files.
+    in_stream = open(parms.infile, "r")
+    seek(in_stream, header_in.header_size)
+    out_stream = open(parms.outfile, "w")
+
+    # Convert time start/stop in e.t. seconds to time sample index values.
+    ix_t_first = trunc(Int64, parms.t_start / header_in.tsamp) + 1
+    ix_t_last = trunc(Int64, parms.t_stop / header_in.tsamp) + 1
+    if ix_t_last < ix_t_first 
+        msg = @sprintf("fb2fb_copy FATAL ix_t_last(%d) < ix_t_first (%d)", 
+                        ix_t_last, ix_t_first)
+        oops(msg)
+    end
+    if parms.flag_debug
+        @printf("fb2fb_copy DEBUG: f_start: %f, f_stop: %f, f_ch1: %f, foff: %e\n", 
+                parms.f_start, parms.f_stop, header_in.fch1, header_in.foff)
+        println("fb2fb_copy DEBUG: ix_t_first = ", ix_t_first)
+        println("fb2fb_copy DEBUG: ix_t_last = ", ix_t_last)
+    end
+    
+    # Convert frequency start/stop to offsets within the entire spectrum (1 time sample).
+    bytesize, remainder = divrem(header_in.nbits, 8) # nbits must be a multiple of 8
+    if remainder != 0
+        msg = @sprintf("Header.nbits = %d is invalid; myst be a multiple of 8", header_in.nbits)
+        oops(msg)
+    end
+    spoff_f_start = bytesize * trunc(Int64, abs((parms.f_start - header_in.fch1) / header_in.foff))
+    spoff_f_uprbnd = bytesize * (trunc(Int64, abs((parms.f_stop + header_in.foff - header_in.fch1) / header_in.foff)))
+    sample_size_out = spoff_f_uprbnd - spoff_f_start
+    if parms.flag_debug
+        println("fb2fb_copy DEBUG: spoff_f_start = ", spoff_f_start)
+        println("fb2fb_copy DEBUG: spoff_f_uprbnd = ", spoff_f_uprbnd)
+        println("fb2fb_copy DEBUG: sample_size_out = ", sample_size_out)
+    end
+
+    # Write updated header to output stream.
+    header_out::Filterbank.Header = deepcopy(header_in)
+    header_out["tstart"] = header_in.tstart + Float64(ix_t_first - 1) * header_in.tsamp / SEC_PER_DAY
+    header_out["nsamps"] = ix_t_last - ix_t_first + 1
+    header_out["fch1"] = parms.f_start
+    header_out["nchans"] = Int64(sample_size_out / bytesize)
+    header_out["sample_size"] = sample_size_out
+    header_out["data_size"] = header_out.sample_size * header_out.nsamps
+    if header_in.tstart != header_out.tstart
+        isot_in = TTEpoch(header_in.tstart * AstroTime.days, origin=:modified_julian)
+        isot_out = TTEpoch(header_out.tstart * AstroTime.days, origin=:modified_julian)
+        println("fb2fb_copy: Header tstart $isot_in ==> $isot_out")
+    end
+    if header_in.nsamps != header_out.nsamps
+        println("fb2fb_copy: Header nsamps ", header_in.nsamps, " ==> ", header_out.nsamps)
+    end
+    if header_in.fch1 != header_out.fch1
+        println("fb2fb_copy: Header fch1 ", header_in.fch1, " ==> ", header_out.fch1)
+    end
+    if header_in.nchans != header_out.nchans
+        println("fb2fb_copy: Header nchans ", header_in.nchans, " ==> ", header_out.nchans)
+    end
+    if header_in.sample_size != header_out.sample_size
+        println("fb2fb_copy: Header sample_size ", header_in.sample_size, " ==> ", header_out.sample_size)
+    end
+    if header_in.data_size != header_out.data_size
+        pct::Float64 = 100.0 * Float64(header_out.data_size) / Float64(header_in.data_size)
+        @printf("fb2fb_copy: Header data_size %d ==> %d (%.1f%% of original)\n", 
+                header_in.data_size, header_out.data_size, pct)
+    end
+    parms.flag_debug && (file_overview("Output file (DEBUG)", header_out, parms))
+    write(out_stream, header_out)
+    parms.flag_debug && (eof_watch(out_stream, "DEBUG wrote header to output stream"))
+
+    # For each selected time sample, copy databytes from the selected frequency range.
+    buffer = Array{UInt8, 1}(undef, header_in.sample_size) # parms.maxbufsz ???
+    for ndx in (1 : header_in.nsamps)
+        if ndx < ix_t_first # Not yet ... skip this spectrum sample.
+            skip(in_stream, header_in.sample_size)
+            continue
+        end
+        ndx > ix_t_last && break # Done!
+        # Process the current spectrum.
+        spoff_f_start > 0 && skip(in_stream, spoff_f_start)
+        readbytes!(in_stream, buffer, sample_size_out)
+        write(out_stream, buffer)
+        parms.flag_debug && (eof_watch(out_stream, "fb2fb_copy DEBUG ndx=$ndx, wrote $sample_size_out bytes"))
+        next_skipsz = header_in.sample_size - spoff_f_start - sample_size_out
+        next_skipsz > 0 && (skip(in_stream, next_skipsz))
+    end
+    
+    # Close files.
+    close(out_stream)
+    close(in_stream)
+    println("fb2fb_copy: Output file size = ", edited_size(filesize(parms.outfile)))
+    @printf("fb2fb_copy: Output data Shape = (%d, %d, %d)\n", 
+            header_out.nsamps, header_out.nifs, header_out.nchans)
+    
+    # Bye bye.
+    t2 = time()
+    @printf("fb2fb_copy: Elapsed time = %.2f seconds\n", t2 - t1)
+    println("fb2fb_copy: End")
+
+end

--- a/src/FbfUtil.jl
+++ b/src/FbfUtil.jl
@@ -1,0 +1,260 @@
+#=
+Module for copying a Filterbank file to another Filterbank file or to an HDF5 file.
+The input file can be subsetted by f_start to f_stop and/or t_start to t_stop.
+=#
+
+module FbfUtil
+
+export PgmParameters
+
+import Base.Filesystem
+import Base.get
+import Printf: @printf, @sprintf
+using Dates
+using ArgParse
+using OrderedCollections
+using AstroTime
+
+const TFMT = dateformat"HH:MM:SS.sss"
+const VERSION = "0.20210206"
+
+const Telescopes = Dict(
+        0 => "Fake data",
+        1 => "Arecibo",
+        2 => "Ooty",
+        3 => "Nancay",
+        4 => "Parkes",
+        5 => "Jodrell",
+        6 => "GBT",
+        8 => "Effelsberg",
+        10 => "SRT",
+        64 => "MeerKAT",
+        65 => "KAT7"
+        )
+
+mutable struct PgmParameters
+    infile::String
+    outfile::String
+    flag_debug::Bool
+    freq_last::Float64
+    tsamp_last::Float64
+    f_start::Float64
+    f_stop::Float64
+    t_start::Float64
+    t_stop::Float64
+###    maxbufsz::Int64
+    # Instantiation function:
+    PgmParameters() = new()
+end
+
+include("Filterbank.jl")
+include("Fb2FbCopy.jl")
+
+
+validate_verb(str::AbstractString) = str == "info" || str == "copy"
+
+
+function parse_commandline()
+    settings = ArgParseSettings()
+    settings.description = "Copy a Filterbank file to another Filterbank file or to an HDF5 file."
+    @add_arg_table! settings begin
+        "verb"
+            help = "Command verb: info, copy."
+            arg_type = String
+            range_tester = validate_verb
+            required = true
+        "infile"
+            help = "Input Filterbank file for all commands."
+            arg_type = String
+            required = true
+        "outfile"
+            help = "Output Filterbank or HDF5 file if performing a full or subset copy."
+            arg_type = String
+            required = false
+        "--debug", "-d"
+            help = "DEBUG output? (true/false)"
+            action = :store_true
+        "--fstart"
+            help = "Start frequency in MHz.  Default: Frequency of first input file channel."
+            arg_type = Float64
+        "--fstop"
+            help = "Stop frequency in MHz.  Default: Frequency of last input file channel."
+            arg_type = Float64
+        "--tstart"
+            help = "Start integration elapsed time in seconds, relative to 0.  Default: 0."
+            arg_type = Float64
+        "--tstop"
+            help = "Stop integration elapsed time in seconds, relative to 0.  Default: Last input file time integration."
+            arg_type = Float64
+###        "--maxbufsz", "-M"
+###            help = "Maximum I/O buffer size in bytes."
+###            arg_type = Int64
+###            default = 100000000
+    end
+    parsed_args = parse_args(settings)
+    return parsed_args
+end
+
+
+function format_angle(ddorhh::Float64)
+    nanos = 0.0
+    try
+        nanos = Dates.Nanosecond(ddorhh * 3600.0 * 1e9)
+    catch
+        println("*** FbfUtil WARNING: Invalid angle detected ($ddorhh).  Using 0.0 instead.")
+    end
+    mytime = Dates.Time(nanos)
+    return Dates.format(mytime, TFMT)
+end
+
+
+function file_overview(label::String, header::Filterbank.Header, parms::PgmParameters)
+    println("$label header:")
+    for (kw, value) in header
+        if kw in Set([:src_dej, :src_raj])
+            angfmt = format_angle(value)
+            println("  $kw : $angfmt")
+        elseif kw == :tstart
+            isot = TTEpoch(value * AstroTime.days, origin=:modified_julian)
+            println("  tstart (ISOT) : $isot")
+            println("  tstart (MJD) : $value")
+        elseif kw == :telescope_id
+            telescope_name = get(Telescopes, value, "UNDEFINED")
+            println("  telescope : $telescope_name ($value)")
+        else
+            println("  $kw : $value")
+        end
+    end
+    if header.foff < 0  # descending values
+        minfreq = parms.freq_last
+        maxfreq = header.fch1
+    else  # ascending values
+        minfreq = header.fch1
+        maxfreq = parms.freq_last
+    end
+    @printf("Data Shape: (%d, %d, %d)\n", header.nsamps, header.nifs, header.nchans)
+    @printf("%s : %f\n", "Minimum file frequency (MHz)", minfreq)
+    @printf("%s : %f\n", "Maximum file frequency (MHz)", maxfreq)
+
+    return nothing
+end
+
+
+function oops(msg::AbstractString)
+    println("\n*** Oops, $msg\n")
+    #ccall(:jl_exit, Cvoid, (Int32,), 86) # Exit to O/S with status code 86
+    exit(86)
+end
+
+
+function main(args)
+    # Parse the command line.
+    println("FbfUtil version $VERSION")
+    parms = PgmParameters()
+    parsed_args = parse_commandline()
+    parms.flag_debug = parsed_args["debug"]
+    parms.infile = abspath(parsed_args["infile"])
+
+    # Loop through parameters.  If a value was specified, print kw & value.
+    println("FbfUtil: Command line parameters:")
+    for (key, value) in sort(parsed_args)
+        ! isnothing(value) && println("  $key : $value")           
+    end
+
+    # Get the header of the input file.
+    if ! isfile(parms.infile)
+        msg = @sprintf("no such file exists: %s", parms.infile)
+        oops(msg)
+    end
+    infh = open(parms.infile, "r")
+    header::Filterbank.Header = read(infh, Filterbank.Header)
+    close(infh)
+    parms.freq_last = header.fch1 + (header.nchans - 1) * header.foff
+    parms.tsamp_last = header.tsamp * (Float64(header.nsamps) - 1) + 0.999
+
+    # Set up f_start.
+    if isnothing(parsed_args["fstart"])
+        parms.f_start = header.fch1
+    else
+        parms.f_start = parsed_args["fstart"]
+    end
+
+    # Set up f_stop.
+    if isnothing(parsed_args["fstop"])
+        parms.f_stop = header.fch1 + (header.nchans - 1) * header.foff
+    else
+        parms.f_stop = parsed_args["fstop"]
+    end
+
+    # Validate f_start and f_stop.
+    if header.foff > 0
+        if ! ( header.fch1 <= parms.f_start <= parms.f_stop <= parms.freq_last )
+            msg = @sprintf("required: %f <= fstart (%f) <= fstop (%f) <= %f.", 
+                           header.fch1, parms.f_start, parms.f_stop, parms.freq_last)
+            oops(msg)
+        end
+    else #= header.foff < 0 =#
+        if ! ( header.fch1 >= parms.f_start >= parms.f_stop >= parms.freq_last )
+            msg = @sprintf("required: %f >= fstart (%f) >= fstop (%f) >= %f.", 
+                           header.fch1, parms.f_start, parms.f_stop, parms.freq_last)
+            oops(msg)
+        end
+    end
+
+    # Set up t_start.
+    if isnothing(parsed_args["tstart"])
+        parms.t_start = 0.0
+    else
+        parms.t_start = parsed_args["tstart"]
+    end
+
+    # Set up t_stop.  Make sure it isn't too large.'
+    if isnothing(parsed_args["tstop"])
+        parms.t_stop = parms.tsamp_last
+    else
+        parms.t_stop = parsed_args["tstop"]
+        if parms.tsamp_last <= parms.t_stop 
+            @printf("*** FbfUtil WARNING: The provided --tstop parameter (%f) indicates\n", parms.t_stop)
+            println("\t\t\ta time that is beyond the last time integration of the input file.")
+            println("FbfUtil: Proceeding as if that parameter was not specified.")
+            parms.t_stop = parms.tsamp_last
+        end
+    end
+    
+    # Validate t_start and t_stop.
+    if ! ( parms.tsamp_last >= parms.t_stop >= parms.t_start >= 0.0 )
+        msg = @sprintf("required: %f >= tstop (%f) >= tstart (%f) >= 0.", 
+                       parms.tsamp_last, parms.t_stop, parms.t_start, )
+        oops(msg)
+    end
+    
+    # Based on command verb, dispatch to the appropriate function.
+    if parsed_args["verb"] == "info"
+        # Get an overview of the input file.
+        file_overview("Input file", header, parms)
+    else # "copy"
+        # Validate nifs.
+        if header.nifs != 1
+            msg = @sprintf("header nifs values other than 1 are not yet supported: %d", header.nifs)
+            oops(msg)
+        end
+        # Make sure that an output file was specified.
+        isnothing(parsed_args["outfile"]) && oops("required: output file specification")
+        parms.outfile = abspath(parsed_args["outfile"])
+        # Validate output file extension.
+        rubbish, outfile_ext = splitext(basename(parsed_args["outfile"]))
+        if outfile_ext == ".h5"
+            msg = @sprintf("HDF5 output files are not yet supported: %s", parsed_args["outfile"])
+            oops(msg)
+        end
+        fb2fb_copy(header, parms)
+    end
+
+    return nothing
+end
+
+
+main(ARGS)
+
+
+end # module fbfcopy


### PR DESCRIPTION
To do:
* NIFS
* HDF5 support
* Use the Project.toml version ID instead of the date as a program version.

HDF5 support in Julia:  https://github.com/JuliaIO/HDF5.jl

Julia, in early 2021, is still too slow (frustrating) for small-ish programs (E.g. 10 seconds just to compile the Filterbank utility on my laptop).  On the other hand, I can see that a complex compute-intensive function set like turbo_seti FindDoppler.search_coarse_channel() which has significant repetition would be interesting to compare to Python/Numba in terms of performance - intuition on my part.  

Still, I do like the Julia syntax and semantics as a language.  If Julia can ever achieve compiler code-generation capability similar to gfortran and C/C++, it will be a formidable competitor.